### PR TITLE
Remove OSS LLMs from the menu

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -50,7 +50,7 @@
     },
     {
       "group": "Improve your copilot",
-      "pages": ["improve/customize-your-copilot", "improve/prompting", "improve/knowledge-base", "improve/evaluation", "improve/debugging", "improve/opensource-llms"]
+      "pages": ["improve/customize-your-copilot", "improve/prompting", "improve/knowledge-base", "improve/evaluation", "improve/debugging"]
     },
     {
       "group": "Integrate your copilot",


### PR DESCRIPTION
The menu sidebar will no longer display the OSS LLM page.